### PR TITLE
[hostcfg] Fix timezone mismatch after image upgrade

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1538,6 +1538,10 @@ class DeviceMetaCfg(object):
             run_cmd(['systemctl', 'restart', 'rsyslog'], True, False)
             syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restarted rsyslog after timezone change')
 
+        except OSError as e:
+            syslog.syslog(syslog.LOG_ERR, f'DeviceMetaCfg: Invalid timezone files for {ETC_LOCALTIME} {new_tz}: {e}')
+        except subprocess.CalledProcessError as e:
+            syslog.syslog(syslog.LOG_ERR, f'DeviceMetaCfg: Failed to set-timezone {new_tz} and restart rsyslog: {e}')
         except Exception as e:
             syslog.syslog(syslog.LOG_ERR, f'DeviceMetaCfg: Failed to apply timezone {new_tz}: {e}')
 

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -50,6 +50,8 @@ MKHOME_DIR_LIB_REG = r'.*pam_mkhomedir'
 ETC_PAMD_SSHD = "/etc/pam.d/sshd"
 ETC_PAMD_LOGIN = "/etc/pam.d/login"
 ETC_LOGIN_DEF = "/etc/login.defs"
+ETC_LOCALTIME = "/etc/localtime"
+ZONEINFO_DIR = "/usr/share/zoneinfo"
 
 # Linux login.def default values (password hardening disable)
 LINUX_DEFAULT_PASS_MAX_DAYS = 99999
@@ -1474,6 +1476,17 @@ class DeviceMetaCfg(object):
 
         # Load appropriate config
         self.timezone = dev_meta.get('localhost', {}).get('timezone')
+        if self.timezone:
+            try:
+                desired_tz = os.path.realpath(f"{ZONEINFO_DIR}/{self.timezone}")
+                current_tz = os.path.realpath(ETC_LOCALTIME)
+                if desired_tz != current_tz:
+                    run_cmd(['timedatectl', 'set-timezone', self.timezone])
+                    syslog.syslog(syslog.LOG_INFO, f'Applied initial timezone: {self.timezone}')
+                    run_cmd(['systemctl', 'restart', 'rsyslog'])
+                    syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog after changing timezone')
+            except Exception as e:
+                syslog.syslog(syslog.LOG_ERR, f"Failed to set initial timezone {self.timezone}: {e}")
         self.syslog_with_osversion = dev_meta.get('localhost', {}).get('syslog_with_osversion')
 
     def hostname_update(self, data):

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1476,17 +1476,7 @@ class DeviceMetaCfg(object):
 
         # Load appropriate config
         self.timezone = dev_meta.get('localhost', {}).get('timezone')
-        if self.timezone:
-            try:
-                desired_tz = os.path.realpath(f"{ZONEINFO_DIR}/{self.timezone}")
-                current_tz = os.path.realpath(ETC_LOCALTIME)
-                if desired_tz != current_tz:
-                    run_cmd(['timedatectl', 'set-timezone', self.timezone])
-                    syslog.syslog(syslog.LOG_INFO, f'Applied initial timezone: {self.timezone}')
-                    run_cmd(['systemctl', 'restart', 'rsyslog'])
-                    syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog after changing timezone')
-            except Exception as e:
-                syslog.syslog(syslog.LOG_ERR, f"Failed to set initial timezone {self.timezone}: {e}")
+        self.apply_timezone_if_needed(self.timezone)
         self.syslog_with_osversion = dev_meta.get('localhost', {}).get('syslog_with_osversion')
 
     def hostname_update(self, data):
@@ -1519,34 +1509,46 @@ class DeviceMetaCfg(object):
                 return
             run_cmd(['sudo', 'monit', 'reload'])
 
+    def apply_timezone_if_needed(self, new_tz):
+        """
+        Apply timezone if it differs from either:
+        - the cached DB value (self.timezone)
+        - the actual system timezone (/etc/localtime)
+        Run the following command in Linux: timedatectl set-timezone <timezone>
+
+        Args:
+            new_tz: New timezone value from DB
+        """
+        try:
+            syslog.syslog(syslog.LOG_DEBUG, f'DeviceMetaCfg: timezone update to {new_tz}')
+            if new_tz is None:
+                syslog.syslog(syslog.LOG_DEBUG, 'DeviceMetaCfg: Recieved empty timezone')
+                return
+            
+            system_timezone_realpath = os.path.realpath(ETC_LOCALTIME)
+            new_timezone_realpath = os.path.realpath(f'{ZONEINFO_DIR}/{new_tz}')
+            if new_tz == self.timezone and new_timezone_realpath == system_timezone_realpath:
+                syslog.syslog(syslog.LOG_DEBUG, 'DeviceMetaCfg: No change in timezone')
+                return
+
+            run_cmd(['timedatectl', 'set-timezone', new_tz])
+            self.timezone = new_tz
+            syslog.syslog(syslog.LOG_INFO, f'DeviceMetaCfg: Applied timezone {self.timezone}')
+
+            run_cmd(['systemctl', 'restart', 'rsyslog'], True, False)
+            syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restarted rsyslog after timezone change')
+
+        except Exception as e:
+            syslog.syslog(syslog.LOG_ERR, f'DeviceMetaCfg: Failed to apply timezone {new_tz}: {e}')
+
     def timezone_update(self, data):
         """
-        Apply timezone handler.
-        Run the following command in Linux: timedatectl set-timezone <timezone>
+        Call apply timezone handler.
+
         Args:
             data: Read table's key's data.
         """
-        new_timezone = data.get('timezone')
-        syslog.syslog(syslog.LOG_DEBUG,
-                      f'DeviceMetaCfg: timezone update to {new_timezone}')
-
-        if new_timezone is None:
-            syslog.syslog(syslog.LOG_DEBUG,
-                          f'DeviceMetaCfg: Recieved empty timezone')
-            return
-
-        if new_timezone == self.timezone:
-            syslog.syslog(syslog.LOG_DEBUG,
-                          f'DeviceMetaCfg: No change in timezone')
-            return
-
-        # run command will print out log error in case of error
-        run_cmd(['timedatectl', 'set-timezone', new_timezone])
-        self.timezone = new_timezone
-
-        run_cmd(['systemctl', 'restart', 'rsyslog'], True, False)
-        syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog after '
-                      'changing timezone')
+        self.apply_timezone_if_needed(data.get('timezone'))
 
     def rsyslog_config(self, data):
         """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -857,8 +857,8 @@ class TestDeviceMetaCfgLoad(TestCase):
     def test_load_initial_timezone_different_from_current(self, mock_syslog, mock_run_cmd, mock_realpath):
         """ Test initial timezone setting when desired timezone differs from current. """
         mock_realpath.side_effect = [
-            '/usr/share/zoneinfo/America/New_York',
-            '/usr/share/zoneinfo/UTC'
+            '/usr/share/zoneinfo/UTC',
+            '/usr/share/zoneinfo/America/New_York'
         ]
         dev_meta = {
             'localhost': {
@@ -871,12 +871,12 @@ class TestDeviceMetaCfgLoad(TestCase):
         
         expected_calls = [
             call(['timedatectl', 'set-timezone', 'America/New_York']),
-            call(['systemctl', 'restart', 'rsyslog'])
+            call(['systemctl', 'restart', 'rsyslog'], True, False)
         ]
         mock_run_cmd.assert_has_calls(expected_calls, any_order=False)
         
         expected_syslog_calls = [
-            call(mock.ANY, 'Applied initial timezone: America/New_York'),
-            call(mock.ANY, 'DeviceMetaCfg: Restart rsyslog after changing timezone')
+            call(mock.ANY, 'DeviceMetaCfg: Applied timezone America/New_York'),
+            call(mock.ANY, 'DeviceMetaCfg: Restarted rsyslog after timezone change')
         ]
         mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -880,3 +880,89 @@ class TestDeviceMetaCfgLoad(TestCase):
             call(mock.ANY, 'DeviceMetaCfg: Restarted rsyslog after timezone change')
         ]
         mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+
+    @mock.patch('hostcfgd.os.path.realpath')
+    @mock.patch('hostcfgd.run_cmd')
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_apply_timezone_oserror_exception(self, mock_syslog, mock_run_cmd, mock_realpath):
+        """ Test OSError exception handling in apply_timezone_if_needed. """
+        mock_realpath.side_effect = [
+            '/usr/share/zoneinfo/UTC',
+            OSError("Permission denied accessing timezone file")
+        ]
+        self.devmeta_cfg.apply_timezone_if_needed('America/New_York')
+        expected_syslog_calls = [
+            call(mock.ANY, 'DeviceMetaCfg: timezone update to America/New_York'),
+            call(mock.ANY, 'DeviceMetaCfg: Invalid timezone files for /etc/localtime America/New_York: Permission denied accessing timezone file')
+        ]
+        mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+        mock_run_cmd.assert_not_called()
+
+    @mock.patch('hostcfgd.os.path.realpath')
+    @mock.patch('hostcfgd.run_cmd')
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_apply_timezone_subprocess_exception(self, mock_syslog, mock_run_cmd, mock_realpath):
+        """ Test subprocess.CalledProcessError exception handling in apply_timezone_if_needed. """
+        mock_realpath.side_effect = [
+            '/usr/share/zoneinfo/UTC',
+            '/usr/share/zoneinfo/America/New_York'
+        ]
+        mock_run_cmd.side_effect = [
+            CalledProcessError(returncode=1, cmd=['timedatectl', 'set-timezone', 'America/New_York'], output="Invalid timezone"),
+            None
+        ]
+        self.devmeta_cfg.apply_timezone_if_needed('America/New_York')
+        expected_syslog_calls = [
+            call(mock.ANY, 'DeviceMetaCfg: timezone update to America/New_York'),
+            call(mock.ANY, 'DeviceMetaCfg: Failed to set-timezone America/New_York and restart rsyslog: Command \'[\'timedatectl\', \'set-timezone\', \'America/New_York\']\' returned non-zero exit status 1.')
+        ]
+        mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+
+    @mock.patch('hostcfgd.os.path.realpath')
+    @mock.patch('hostcfgd.run_cmd')
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_apply_timezone_general_exception(self, mock_syslog, mock_run_cmd, mock_realpath):
+        """ Test general Exception handling in apply_timezone_if_needed. """
+        mock_realpath.side_effect = [
+            '/usr/share/zoneinfo/UTC',
+            '/usr/share/zoneinfo/America/New_York'
+        ]
+        mock_run_cmd.side_effect = RuntimeError("Unexpected system error")
+        self.devmeta_cfg.apply_timezone_if_needed('America/New_York')
+        expected_syslog_calls = [
+            call(mock.ANY, 'DeviceMetaCfg: timezone update to America/New_York'),
+            call(mock.ANY, 'DeviceMetaCfg: Failed to apply timezone America/New_York: Unexpected system error')
+        ]
+        mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+
+    @mock.patch('hostcfgd.os.path.realpath')
+    @mock.patch('hostcfgd.run_cmd')
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_apply_timezone_no_change_needed(self, mock_syslog, mock_run_cmd, mock_realpath):
+        """ Test apply_timezone_if_needed when no change is needed. """
+        mock_realpath.side_effect = [
+            '/usr/share/zoneinfo/America/New_York',
+            '/usr/share/zoneinfo/America/New_York'
+        ]
+        self.devmeta_cfg.timezone = 'America/New_York'
+        self.devmeta_cfg.apply_timezone_if_needed('America/New_York')
+        expected_syslog_calls = [
+            call(mock.ANY, 'DeviceMetaCfg: timezone update to America/New_York'),
+            call(mock.ANY, 'DeviceMetaCfg: No change in timezone')
+        ]
+        mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+        mock_run_cmd.assert_not_called()
+
+    @mock.patch('hostcfgd.os.path.realpath')
+    @mock.patch('hostcfgd.run_cmd')
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_apply_timezone_empty_timezone(self, mock_syslog, mock_run_cmd, mock_realpath):
+        """ Test apply_timezone_if_needed with None/empty timezone. """
+        self.devmeta_cfg.apply_timezone_if_needed(None)  
+        expected_syslog_calls = [
+            call(mock.ANY, 'DeviceMetaCfg: timezone update to None'),
+            call(mock.ANY, 'DeviceMetaCfg: Recieved empty timezone')
+        ]
+        mock_syslog.assert_has_calls(expected_syslog_calls, any_order=False)
+        mock_realpath.assert_not_called()
+        mock_run_cmd.assert_not_called()


### PR DESCRIPTION
**Why I did it**
To fix an issue where newly installed SONiC images default /etc/localtime to UTC even when the previous image
was configured with and used a different timezone, and config save was executed before the image update.
This causes a mismatch between the timezone defined in CONFIG_DB and the one defined in the Linux file /etc/localtime, because when the new image comes up with a new filesystem, the Linux file /etc/localtime is created with the default UTC, while the timezone value in CONFIG_DB (DEVICE_METADATA|localhost|timezone) is preserved from the previous image.

**How I did it**
In src/sonic-host-services/scripts/hostcfgd::DeviceMetaCfg:load, we already read the timezone from CONFIG_DB to save it for future events (DeviceMetaCfg:timezone_update observes changes in DEVICE_METADATA).
So at this point, when hostcfgd is up, we can simply update the Linux file /etc/localtime with the initial correct timezone value from CONFIG_DB by executing (only if it differs from the current /etc/localtime):
timedatectl set-timezone <timezone>
(as is already done in timezone_update).
The same pattern exists in hostcfgd::DnsCfg:load.

**How to verify it**
1. Set a non-UTC timezone on the current image: config clock timezone Asia/Jerusalem
2. Run config save
3. Install a new image
4. Reboot and check that hostcfgd is up: systemctl status hostcfgd (~1m)
5. Verify that the timezone is identical in CONFIG_DB and /etc/localtime:
timedatectl
date
cat /etc/localtime
cat /etc/sonic/config_db.json | grep timezone
hget "DEVICE_METADATA|localhost" "timezone"